### PR TITLE
fix link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tessel.io website
 
-This is the website codebase for <tessel.io>.
+This is the website codebase for [tessel.io](//tessel.io).
 
 ##Dev
 


### PR DESCRIPTION
@tcr it was `<tessel.io>` which just disappears in markdown
