### PR TITLE
added t2-start redirect

### DIFF
--- a/index.js
+++ b/index.js
@@ -261,6 +261,10 @@ app.get('/start', function(req, res) {
   res.redirect('http://start.tessel.io');
 });
 
+app.get('/t2-start', function(req, res) {
+  res.redirect('http://tessel.github.io/t2-start/');
+});
+
 app.get('/install', function(req, res) {
   res.redirect('http://start.tessel.io');
 });


### PR DESCRIPTION
Adds a redirect so that if you go to `tessel.io/t2-start` it redirects to the t2 start experience.

Pros:
- I can never remember `http://tessel.github.io/t2-start/`; this is more memorable.
- This is similar to how `tessel.io/start` redirects to `start.tessel.io`

Cons:
- It's pretty confusing trying to disambiguate the two start experiences already, since they look basically identical. It's possible that this is even more confusing, but I'm not sure.

Any thoughts on this @johnnyman727 @rwaldron @scottgonzalez anyone else who runs hackathons?
