### PR TITLE
Adds contact information to the faq

### DIFF
--- a/faq.json
+++ b/faq.json
@@ -16,4 +16,7 @@
 }, {
   "q": "Can I use my own USB devices?",
   "a": "Yes. First-party modules will have high-level APIs and be tested to ensure driver support, but you can also add your own USB devices if the drivers are compatible and/or you dive a little deeper into the OpenWrt ecosystem."
+}, {
+  "q": "I have more questions! How can I contact you?",
+  "a": "For quick questions, we're <a href='//twitter.com/tesselproject'>@tesselproject</a> on Twitter. Longer questions are welcome on our <a href='//tessel.io/forums'>forums</a>, and questions about orders can be sent to <a href='mailto:support@tessel.io'>support at tessel.io</a>.</p>"
 }]


### PR DESCRIPTION
At the bottom of [tessel.io](//tessel.io), in the faq section, adds contact information. Renders as:

![screen shot 2015-10-28 at 3 37 50 pm](https://cloud.githubusercontent.com/assets/454690/10793751/1c94218a-7d8a-11e5-8301-8169bd099b78.png)

@johnnyman727 @rwaldron @tcr is this how we would like to be contacted?

@heavyk would this have been helpful for you?
