### PR TITLE
Set the server’s fqdn to be tessel.io

### DIFF
--- a/deploy/ansible/group_vars/all.yml
+++ b/deploy/ansible/group_vars/all.yml
@@ -18,8 +18,8 @@ hostname: "{{project_name}}"
 # nginx checks this value against the URL being requested, it must be the same
 # as the server's DNS name. This value is overridden for Vagrant and staging
 # servers.
-site_fqdn: "{{project_name}}.bocoup.com"
-# site_fqdn: "tessel.io"
+# site_fqdn: "{{project_name}}.bocoup.com"
+site_fqdn: "tessel.io"
 
 ##############
 # PROVISIONING


### PR DESCRIPTION
This should tell nginx to use tessel.io but keep mgmt functions active at tessel-io.bocoup.com

@tkellen did I miss anything?
