### PR TITLE
add redirect to slack invite page at tessel.io/slack

### DIFF
--- a/index.js
+++ b/index.js
@@ -297,6 +297,10 @@ app.get('/diy', function(req, res) {
   res.redirect('/docs/DIYModule');
 });
 
+app.get('/slack', function(req, res) {
+  res.redirect('https://tessel-slack.herokuapp.com/');
+});
+
 // Pull the docs from GitHub
 var rawDocs = {
   home: {


### PR DESCRIPTION
This is a link I've looked up over and over again, thought having a simpler URL would be useful.

r? @tcr
