### PR TITLE
change /start to go to t2-start

### DIFF
--- a/index.js
+++ b/index.js
@@ -251,6 +251,10 @@ app.get('/start', function(req, res) {
   res.redirect('http://tessel.github.io/t2-start/');
 });
 
+app.get('/t1-start', function(req, res) {
+  res.redirect('http://start.tessel.io');
+});
+
 app.get('/t2-start', function(req, res) {
   res.redirect('http://tessel.github.io/t2-start/');
 });

--- a/index.js
+++ b/index.js
@@ -248,7 +248,7 @@ app.get('/opensource', function(req, res) {
 });
 
 app.get('/start', function(req, res) {
-  res.redirect('http://start.tessel.io');
+  res.redirect('http://tessel.github.io/t2-start/');
 });
 
 app.get('/t2-start', function(req, res) {


### PR DESCRIPTION
Updates /start redirect to go to the t2 start. You can still get to Tessel 1 start (linked from t2 start's home page and hosted at start.tessel.io).

We need this because the stickers we're shipping out tell people to go to tessel.io/start to get started.

Should send a blast out to #team-members when this goes live so that no one gets confused giving a workshop or presentation.
