### PR TITLE
Render URLs in community-created modules

### DIFF
--- a/views/modules.jade
+++ b/views/modules.jade
@@ -450,7 +450,7 @@ block content
                 | View on npm &rarr;
           div.large-8.columns
             h4(style="margin-top:-30px") #{ucfirst(val.name)}
-            p #{val.description}
+            p !{val.description}
             - var authorLink = "//github.com/" + val.author.github
             p Author: <a href=#{authorLink} target="_blank">#{val.author.name}</a>
             h3


### PR DESCRIPTION
The description of the [Lego module](https://tessel.io/modules#lego-ir) contains a URL which is escaped in the current Jade template:

**Screenshot**
![Screenshot](https://cloud.githubusercontent.com/assets/469989/15805390/de5100da-2b28-11e6-8751-d7f8de4598e5.PNG)

Because I consider [modules.json](https://github.com/tessel/hardware-modules/blob/master/modules.json) as safe source, I decided it's okay to unescape descriptions from the payload of this file.

If you disagree I could also write a regular expression which removes the anchor tags completly. Another option would be to remove URLs from `modules.json`.

What do you think?
