### PR TITLE
Adds Sparkfun links to Resellers page and homepage, breaks out reseller items

### DIFF
--- a/views/index.jade
+++ b/views/index.jade
@@ -31,7 +31,9 @@ block content
       h3.header__hook Build your idea faster.
       p Tessel 2 is a robust IoT and robotics development platform. Leverage all the libraries of Node.JS to create useful devices in minutes with Tessel.
       a.button.pre-order__button.button.round.large(href="http://www.seeedstudio.com/depot/Tessel-2-p-2622.html?ref=tessel.io")
-        | Order from Seeed Studio
+        | Order from Seeed Studio (China/Global)
+      a.a.button.pre-order__button.button.round.large(href="https://www.sparkfun.com/products/13841?ref=tessel.io")
+        | Order from Sparkfun (USA/Global)
   .row.full-width#js-animation-area.animation-area
     .show-for-small-only
       img.board__image(src="https://s3.amazonaws.com/technicalmachine-assets/launch/tessel2-800x600.jpg")
@@ -364,7 +366,9 @@ block content
   .row.full-width.last-call#lastcall
     .column.large-centered.text-center
       a.button.pre-order__button.button.round.large(href="http://www.seeedstudio.com/depot/Tessel-2-p-2622.html?ref=tessel.io")
-        | Order from Seeed Studio
+        | Order from Seeed Studio (China/Global)
+      a.a.button.pre-order__button.button.round.large(href="https://www.sparkfun.com/products/13841?ref=tessel.io")
+        | Order from Sparkfun (USA/Global)
       p.subscribe Keep up to date on our progress. #[a(href="http://eepurl.com/EoMoP") Join our mailing list.]
   //- This are used in index.js for line animations
   //- Do not remove

--- a/views/resellers.jade
+++ b/views/resellers.jade
@@ -1,14 +1,18 @@
 extends layout
 <meta name="Description" content="Tessel resellers: hardware + the web.">
 
-mixin reseller(name, region, link, image)
+mixin reseller(name, region, link, image, items)
   div(style="padding-top:10px;")
     b 
-      a(href="#{link}", target="_blank") #{name}&nbsp;
-    | (#{region})
+      a(href="#{link}", target="_blank")
+        h3 #{name} (#{region})
     p 
       a(href="#{link}", target="_blank")
-        img(style="padding:5px", src="https://s3.amazonaws.com/technicalmachine-assets/launch/resellers/#{image}")
+        img(style="padding:5px; width:200px", src=image)
+    ul
+      each item in items
+        li
+          a(href=item.link) #{item.name}
 
 block content
   include ./partials/standard-nav
@@ -19,7 +23,9 @@ block content
         p Interested in becoming a reseller? <a href="https://www.seeedstudio.com/depot/index.php?main_page=distributors">Contact Seeed</a>.
         
         p
-          +reseller('Seeed Studio', '中国 China/Global', 'http://www.seeedstudio.com/depot/Tessel-m-153.html?ref=pinfo', 'seeed_studio.gif')
+          +reseller('Seeed Studio', '中国 China/Global', 'http://www.seeedstudio.com/depot/Tessel-m-153.html?ref=pinfo', 'http://www.seeedstudio.com/blog/wp-content/uploads/2015/03/2014%E6%96%B0LOGO011-e1426747545587.jpg', [{name: 'Tessel 2', link: 'https://www.seeedstudio.com/item_detail.html?p_id=2622'}, {name: 'Servo Module', link: 'http://www.seeedstudio.com/depot/Tessel-Servo-Module-p-2311.html'}, {name: 'GPS Module', link: 'http://www.seeedstudio.com/depot/Tessel-GPS-p-2683.html'}, {name: 'Relay Module', link: 'http://www.seeedstudio.com/depot/Tessel-Relay-Module-p-2309.html'}, {name: 'RFID Module', link: 'http://www.seeedstudio.com/depot/Tessel-RFID-Module-p-2228.html'}, {name: 'Climate Module', link: 'http://www.seeedstudio.com/depot/Tessel-Climate-Module-p-2225.html'}, {name: 'Infrared Module', link: 'http://www.seeedstudio.com/depot/Tessel-IR-Module-p-2224.html'}, {name: 'Accelerometer Module', link: 'http://www.seeedstudio.com/depot/Tessel-Accelerometer-Module-p-2223.html'}, {name: 'Ambient Module', link: 'http://www.seeedstudio.com/depot/Tessel-Ambient-Module-p-2220.html'}])
+
+          +reseller('Sparkfun', 'USA/Global', 'https://www.sparkfun.com/products/13841', 'https://upload.wikimedia.org/wikipedia/en/thumb/0/02/Sparkfun_logo.svg/1280px-Sparkfun_logo.svg.png', [{name: 'Tessel 2', link: 'https://www.sparkfun.com/products/13841'}, {name: 'Johnny-Five Inventor\'s Kit', link: 'https://www.sparkfun.com/products/13847'}])
           
           //- UNCOMMENT ONCE TELEC FIXED
           //- +reseller('Switch Science', '日本 Japan', 'https://www.switch-science.com/catalog/list/558/', 'switch_science.gif')
@@ -28,4 +34,4 @@ block content
 
         h3 Bulk Pricing
         
-        p Planning to make a large order? <a href="http://www.seeedstudio.com/depot/Tessel-m-153.html?ref=pinfo">Seeed's site has a price break at 10+</a>; further price breaks can be had for 50+ and 100+. Please <a href="mailto:team@technical.io">send us an email</a> if you're interested in these larger numbers.
+        p Planning to make a large order? <a href="http://www.seeedstudio.com/depot/Tessel-m-153.html?ref=pinfo">Seeed's site has a price breaks at 10+</a>; further price breaks can be had for 50+ and 100+. Email team at tessel.io if interested in higher quantities.


### PR DESCRIPTION
Homepage:

![screen shot 2016-07-13 at 4 48 41 pm](https://cloud.githubusercontent.com/assets/454690/16809881/c539b2a4-4919-11e6-8c5b-2cb3dd8ef81f.png)

Resellers page:

![screen shot 2016-07-13 at 4 44 21 pm](https://cloud.githubusercontent.com/assets/454690/16809887/cab3913c-4919-11e6-9e77-d705a880676d.png)

Thoughts on this double-button approach to the homepage? @reconbot @HipsterBrown 
