### PR TITLE
fix links on modules page

### DIFF
--- a/views/modules.jade
+++ b/views/modules.jade
@@ -201,7 +201,7 @@ block content
             p
               | Build your own module!
             p This single- or double-wide module comes with a
-              a(href="/diy") guide
+              a(href="/diy") &nbsp;guide&nbsp;
               | showing you how to connect anything to a Tessel.
             ul
               li Protoboard module exposes SPI, I2C, UART, and GPIO
@@ -306,7 +306,7 @@ block content
               li Standard PWM output is compatible with servos of all sizes
               li Takes a separate barrel jack power connection (included with US shipments)
               li Comes with an
-                a(href="/datasheets/YinYanES3001.pdf") ES3001 YinYan Servo
+                a(href="/datasheets/YinYanES3001.pdf") &nbsp;ES3001 YinYan Servo&nbsp;
                 | and a 5V external power jack (US-style plug)
               li Can also be used as an LED driver.
             +to-fre('servo')
@@ -332,7 +332,7 @@ block content
             div.large-8.columns
               h4 USB #{ucfirst(val.name)}
               p USB #{ucfirst(val.name)} Module for Tessel 2.
-              p #{val.description}
+              p !{val.description}
 
     .row#third-party
       p


### PR DESCRIPTION
### Purpose
This PR closes #119 

### Approach
I updated the modules view to fix formatting around a few links, including the code described in #119: 

Before:
![Screen Shot 2019-10-05 at 17 08 48](https://user-images.githubusercontent.com/17116730/66261040-c94db580-e794-11e9-9b99-075987c9db14.png)

After:
![Screen Shot 2019-10-05 at 17 08 55](https://user-images.githubusercontent.com/17116730/66261044-cf439680-e794-11e9-8ec6-9f8357b08d5b.png)

Before:
![Screen Shot 2019-10-05 at 17 14 57](https://user-images.githubusercontent.com/17116730/66261071-23e71180-e795-11e9-864b-ee8f7a1c5482.png)

After:
![Screen Shot 2019-10-05 at 17 15 21](https://user-images.githubusercontent.com/17116730/66261074-2b0e1f80-e795-11e9-9f85-57ea1b61d2e8.png)

Before:
![Screen Shot 2019-10-05 at 17 15 56](https://user-images.githubusercontent.com/17116730/66261083-57c23700-e795-11e9-876b-6e0c58a936e7.png)

After:
![Screen Shot 2019-10-05 at 17 16 11](https://user-images.githubusercontent.com/17116730/66261086-5d1f8180-e795-11e9-9120-3183df7a708c.png)
